### PR TITLE
Data re-arrangement and comprehensive fixes

### DIFF
--- a/test.py
+++ b/test.py
@@ -30,35 +30,44 @@ class TestTypeform(unittest.TestCase):
         )
 
     def test_results(self):
+        form_name = 'Test Survey'
         source = {
             'key': 'TypefromAPIKey',
-            'forms': [{'id': 'abc', 'name': 'Test Survey'}]
+            'forms': [{'value': 'abc', 'name': form_name}]
         }
 
         # mock the returned responses from the server
-        responses = [{'id': 0, 'foo_choice': 'bar'}]
+        responses = [{'field_id': 'x', 'token': 'y', 'foo_choice': 'bar'}]
         form_result = generateFormResults(1, responses)
         urllib2.urlopen = MagicMock(return_value=form_result)
 
         stream = Typeform(source, OPTIONS)
 
         results = stream.read()
-        self.assertEqual(results[0].get('foo_choice'), 'bar')
+
+        # each of the records should hold the appropriate destination
+        # name, while the first record is always the general statistics
+        # and from then on it's questions and responses records
         self.assertEqual(results[1].get('foo_choice'), 'bar')
+        self.assertEqual(results[2].get('foo_choice'), 'bar')
 
-        # it should have the destination table name attribute
-        # as the form's name joined with the type ('question'/'answer')
-        expected = 'Test_Survey_questions'
-        self.assertEqual(results[0].get('__table'), expected)
+        self.assertEqual(results[0].get('__table'), '_stats')
+        self.assertEqual(results[1].get('__table'), '_questions')
+        self.assertEqual(results[2].get('__table'), '_responses')
 
-        expected = 'Test_Survey_responses'
-        self.assertEqual(results[1].get('__table'), expected)
+        # it should add the formid_idsuffix
+        self.assertEqual(results[1].get('id'), 'abc_x')
+        self.assertEqual(results[2].get('id'), 'abc_y')
+
+        # all the records should belong to the same form
+        for record in results:
+            self.assertEqual(record.get('__form'), form_name)
 
     def test_incremental(self):
         source = {
             'key': 'TypeformAPIKey',
             'lastTimeSucceed': '2016-09-21T10:23:42.819Z',
-            'forms': [{'id': 'abc', 'name': 'Test Survey'}]
+            'forms': [{'value': 'abc', 'name': 'Test Survey'}]
         }
 
         res = generateFormResults(1)
@@ -73,7 +82,7 @@ class TestTypeform(unittest.TestCase):
         # we're pulling data after a specific date
         url = '%s/form/%s?key=%s&completed=true&offset=0&limit=%s&since=%s' % (
             BASE_URL,
-            source['forms'][0].get('id'),
+            source['forms'][0].get('value'),
             source['key'],
             FETCH_LIMIT,
             time
@@ -83,7 +92,7 @@ class TestTypeform(unittest.TestCase):
     def test_pagination(self):
         source = {
             'key': 'TypeformAPIKey',
-            'forms': [{'id': 'abc', 'name': 'Test Survey'}]
+            'forms': [{'value': 'abc', 'name': 'Test Survey'}]
         }
 
         limit = typeform.FETCH_LIMIT = 1
@@ -101,7 +110,7 @@ class TestTypeform(unittest.TestCase):
         # test that it constructed the correct url
         url = '%s/form/%s?key=%s&completed=true&offset=1&limit=%s' % (
             BASE_URL,
-            source['forms'][0].get('id'),
+            source['forms'][0].get('value'),
             source['key'],
             limit
         )
@@ -111,8 +120,8 @@ class TestTypeform(unittest.TestCase):
         source = {
             'key': 'TypefromAPIKey',
             'forms': [
-                {'id': 'abc', 'name': 'Test Survey'},
-                {'id': 'edf', 'name': 'Test Survey'}
+                {'value': 'abc', 'name': 'Test Survey'},
+                {'value': 'edf', 'name': 'Test Survey'}
             ]
         }
 
@@ -130,7 +139,7 @@ class TestTypeform(unittest.TestCase):
     def test_http_error_msg(self):
         source = {
             'key': 'TypefromAPIKey',
-            'forms': [{'id': 'someid', 'name': 'Test Survey'}]
+            'forms': [{'value': 'someid', 'name': 'Test Survey'}]
         }
 
         err_msg = 'please provide a valid API key'
@@ -152,7 +161,7 @@ class TestTypeform(unittest.TestCase):
     def test_http_error_status(self):
         source = {
             'key': 'TypeformAPIKey',
-            'forms': [{'id': 'someid', 'name': 'Test Survey'}]
+            'forms': [{'value': 'someid', 'name': 'Test Survey'}]
         }
 
         # mock the HTTPError that should be returned from the server

--- a/test.py
+++ b/test.py
@@ -37,7 +37,7 @@ class TestTypeform(unittest.TestCase):
         }
 
         # mock the returned responses from the server
-        responses = [{'field_id': 'x', 'token': 'y', 'foo_choice': 'bar'}]
+        responses = [{'id': 1, 'field_id': 'x', 'token': 'y', 'foo': 'bar'}]
         form_result = generateFormResults(1, responses)
         urllib2.urlopen = MagicMock(return_value=form_result)
 
@@ -48,8 +48,8 @@ class TestTypeform(unittest.TestCase):
         # each of the records should hold the appropriate destination
         # name, while the first record is always the general statistics
         # and from then on it's questions and responses records
-        self.assertEqual(results[1].get('foo_choice'), 'bar')
-        self.assertEqual(results[2].get('foo_choice'), 'bar')
+        self.assertEqual(results[1].get('foo'), 'bar')
+        self.assertEqual(results[2].get('foo'), 'bar')
 
         self.assertEqual(results[0].get('__table'), '_stats')
         self.assertEqual(results[1].get('__table'), '_questions')
@@ -58,6 +58,9 @@ class TestTypeform(unittest.TestCase):
         # it should add the formid_idsuffix
         self.assertEqual(results[1].get('id'), 'abc_x')
         self.assertEqual(results[2].get('id'), 'abc_y')
+
+        # it should keep the original id, if exists
+        self.assertEqual(results[1].get('oid'), 1)
 
         # all the records should belong to the same form
         for record in results:

--- a/test.py
+++ b/test.py
@@ -25,9 +25,7 @@ class TestTypeform(unittest.TestCase):
     def test_destination(self):
         source = {'key': 'TypeformAPIKey'}
         Typeform(source, OPTIONS)
-        self.assertEqual(source['destination'],
-            DESTINATION + DESTINATION_POSTFIX
-        )
+        self.assertEqual(source['destination'], DESTINATION)
 
     def test_results(self):
         form_name = 'Test Survey'
@@ -51,9 +49,9 @@ class TestTypeform(unittest.TestCase):
         self.assertEqual(results[1].get('foo'), 'bar')
         self.assertEqual(results[2].get('foo'), 'bar')
 
-        self.assertEqual(results[0].get('__table'), '_stats')
-        self.assertEqual(results[1].get('__table'), '_questions')
-        self.assertEqual(results[2].get('__table'), '_responses')
+        self.assertEqual(results[0].get('__table'), 'stats')
+        self.assertEqual(results[1].get('__table'), 'questions')
+        self.assertEqual(results[2].get('__table'), 'responses')
 
         # it should add the formid_idsuffix
         self.assertEqual(results[1].get('id'), 'abc_x')

--- a/typeform/typeform.py
+++ b/typeform/typeform.py
@@ -102,12 +102,12 @@ class Typeform(panoply.DataSource):
 
         # questions records
         questions = map(add_attrs('questions', 'field_id'),
-            body.get('questions')
+            body.get('questions', [])
         )
 
         # responses (survey answers) records
         responses = map(add_attrs('responses', 'token'),
-            body.get('responses')
+            body.get('responses', [])
         )
 
         stats.extend(questions + responses)

--- a/typeform/typeform.py
+++ b/typeform/typeform.py
@@ -70,7 +70,15 @@ class Typeform(panoply.DataSource):
             form['offset'] += FETCH_LIMIT
 
 
-        # general results statistics records
+        # When fetching data from the Typeform API, it provides us with
+        # the form questions, responses and general statistics. Instead
+        # of creating multiple tables for each form, We want to create
+        # a single set of tables for the aforementioned statistics.
+        # Note that each row is associated to it's form name,
+        # indicated by the '__form' column.
+
+        # generate a single result statistics record from
+        # the recent pulling
         stats = {
             '__table': 'stats',
             '__form': form.get('name'),
@@ -78,7 +86,6 @@ class Typeform(panoply.DataSource):
             'completed': stats.get('completed'),
             'id': form.get('value')
         }
-        stats = [stats]
 
         # helper method that assists us to add the destination table,
         # form name and generated unique id for a given item.
@@ -110,8 +117,8 @@ class Typeform(panoply.DataSource):
             body.get('responses', [])
         )
 
-        stats.extend(questions + responses)
-        return stats
+        # return all the different types of records in one batch
+        return [stats] + questions + responses
 
 
     # GET all the forms.

--- a/typeform/typeform.py
+++ b/typeform/typeform.py
@@ -99,7 +99,8 @@ class Typeform(panoply.DataSource):
         )
 
         # the body of the result is a list of forms
-        return self._request(url)
+        forms = self._request(url)
+        return map(lambda f: dict(name=f.get('name'), value=f.get('id')), forms)
 
     # Helper function for issuing GET requests 
     def _request(self, url):
@@ -119,7 +120,7 @@ class Typeform(panoply.DataSource):
     def _url(self, form):
         url = '%s/form/%s?key=%s&completed=true&offset=%s&limit=%s' % (
             BASE_URL,
-            form['id'],
+            form['value'],
             self._key,
             form['offset'],
             FETCH_LIMIT

--- a/typeform/typeform.py
+++ b/typeform/typeform.py
@@ -90,7 +90,16 @@ class Typeform(panoply.DataSource):
             def x(item):
                 item['__table'] = dest
                 item['__form'] = form.get('name')
+
+                # we're saving the untouched original id as it comes
+                # back from the server
+                if 'id' in item:
+                    item['oid'] = item.get('id')
+
+                # inject a custom id that's assembled from the form
+                # id and a given unique attribute (e.g. token)
                 item['id'] = '%s_%s' % (form.get('value'), item.get(id_suffix))
+
                 return item
 
             return x

--- a/typeform/typeform.py
+++ b/typeform/typeform.py
@@ -7,8 +7,8 @@ import datetime
 
 
 FETCH_LIMIT = 500
-DESTINATION = 'typeform'
-DESTINATION_POSTFIX = '_{__table}'
+DESTINATION = 'typeform_{__table}'
+# DESTINATION_POSTFIX = '_{__table}'
 BASE_URL = 'https://api.typeform.com/v1'
 DATE_PARSER_FORMAT = '%Y-%m-%dT%H:%M:%S'
 
@@ -23,7 +23,7 @@ class Typeform(panoply.DataSource):
             source['destination'] = DESTINATION
 
         # append the destination postfix, which represent the form name
-        source['destination'] += DESTINATION_POSTFIX
+        # source['destination'] += DESTINATION_POSTFIX
 
         # since we're retrieving only completed surveys we can
         # allow incremental pulling from the last successful batch
@@ -76,7 +76,7 @@ class Typeform(panoply.DataSource):
 
         # general results statistics records
         stats = {
-            '__table': '_stats',
+            '__table': 'stats',
             '__form': form.get('name'),
             'total': stats.get('total'),
             'completed': stats.get('completed'),
@@ -105,12 +105,12 @@ class Typeform(panoply.DataSource):
             return x
 
         # questions records
-        questions = map(add_attrs('_questions', 'field_id'),
+        questions = map(add_attrs('questions', 'field_id'),
             body.get('questions')
         )
 
         # responses (survey answers) records
-        responses = map(add_attrs('_responses', 'token'),
+        responses = map(add_attrs('responses', 'token'),
             body.get('responses')
         )
 

--- a/typeform/typeform.py
+++ b/typeform/typeform.py
@@ -8,7 +8,6 @@ import datetime
 
 FETCH_LIMIT = 500
 DESTINATION = 'typeform_{__table}'
-# DESTINATION_POSTFIX = '_{__table}'
 BASE_URL = 'https://api.typeform.com/v1'
 DATE_PARSER_FORMAT = '%Y-%m-%dT%H:%M:%S'
 
@@ -21,9 +20,6 @@ class Typeform(panoply.DataSource):
 
         if 'destination' not in source:
             source['destination'] = DESTINATION
-
-        # append the destination postfix, which represent the form name
-        # source['destination'] += DESTINATION_POSTFIX
 
         # since we're retrieving only completed surveys we can
         # allow incremental pulling from the last successful batch


### PR DESCRIPTION
[Asana](https://app.asana.com/0/45261296911259/227680659486076)

Made some changes to this data source:
- Single set of tables: this source pulls completed Typeform surveys, so instead of creating a table for each form it collects, it will create one table for all forms (actually one for the `answers`, another one for `responses` and another general `stats` tables - but all three are comprehensive to _all_ the forms).
- On top of the described above, I've adjusted the `idpattern` and `destination` accordingly for each record. 
- The `form.js` _does_ support object like values in a collection, but needs to be constructed in `{name: x, value: y}` - changed accordingly. 

@kfir124 
FYI: @alonbrody 