### PR TITLE
Adds support for different Forms types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# vscode
+.vscode/

--- a/test.py
+++ b/test.py
@@ -245,7 +245,7 @@ class TestTypeform(unittest.TestCase):
         }
 
         res1 = generate_form_results_completed_and_not(10)
-        requests.get = MagicMock(side_effect=[ MockResponse(res1, 200) ])
+        requests.get = MagicMock(side_effect=[MockResponse(res1, 200)])
 
         stream = Typeform(source, OPTIONS)
         stream.read()
@@ -273,7 +273,7 @@ class TestTypeform(unittest.TestCase):
         }
 
         res1 = generate_form_results_completed_and_not(10)
-        requests.get = MagicMock(side_effect=[ MockResponse(res1, 200) ])
+        requests.get = MagicMock(side_effect=[MockResponse(res1, 200)])
 
         stream = Typeform(source, OPTIONS)
         stream.read()
@@ -303,7 +303,7 @@ class TestTypeform(unittest.TestCase):
         }
 
         res1 = generate_form_results_completed_and_not(10)
-        requests.get = MagicMock(side_effect=[ MockResponse(res1, 200) ])
+        requests.get = MagicMock(side_effect=[MockResponse(res1, 200)])
 
         stream = Typeform(source, OPTIONS)
         stream.read()
@@ -379,6 +379,7 @@ def generate_form_results_not_completed(size):
         'page_count': size,
         'items': responses,
     }
+
 
 def generate_form_results_completed_and_not(size):
     not_completed_responses = [{

--- a/typeform/typeform.py
+++ b/typeform/typeform.py
@@ -8,6 +8,12 @@ import requests
 
 BATCH_SIZE = 1000
 DESTINATION = 'typeform'
+FORM_TYPES = {
+    'completed': { 'completed': 1 },
+    'not_completed': { 'completed': 0 },
+    'all': {},
+}
+DEFAULT_FORM_TYPE = 'completed'
 DESTINATION_POSTFIX = '{__table}'
 BASE_URL = 'https://api.typeform.com'
 FORM_RESPONSES_URL = BASE_URL + '/forms/{value}/responses'
@@ -30,6 +36,7 @@ class Typeform(DataSource):
         super(Typeform, self).__init__(source, options)
 
         source['destination'] = source.get('destination', DESTINATION)
+        source['__formTypes'] = source.get('__formTypes', DEFAULT_FORM_TYPE)
         # append the destination postfix
         if DESTINATION_POSTFIX not in source['destination']:
             source['destination'] += '_{}'.format(DESTINATION_POSTFIX)
@@ -113,11 +120,14 @@ class Typeform(DataSource):
     def _build_params(self, form, batch_size):
         """ construct the relevant params according to the Typeform API """
         page_size = batch_size if batch_size else BATCH_SIZE
+        completed = FORM_TYPES[self.source.get('__formTypes')]
         params = {
             'page_size': page_size,
             'sort': 'landed_at,desc',
-            'completed': 1,  # remove the line if you want to include both
+            # 'completed': 1,  # remove the line if you want to include both
         }
+
+        params.update(completed)
 
         # pull data incrementally if configured to do so.
         if self._incval:

--- a/typeform/typeform.py
+++ b/typeform/typeform.py
@@ -9,8 +9,8 @@ import requests
 BATCH_SIZE = 1000
 DESTINATION = 'typeform'
 FORM_TYPES = {
-    'completed': { 'completed': 1 },
-    'not_completed': { 'completed': 0 },
+    'completed': {'completed': 1},
+    'not_completed': {'completed': 0},
     'all': {},
 }
 DEFAULT_FORM_TYPE = 'completed'


### PR DESCRIPTION
Asana: https://app.asana.com/0/280843276935180/797693123667337/f

Typeform is a platform that helps sending forms for users/people to fill up,
sometimes they're not filling up the form, so in order to specify which forms to fetch we need to add some query-params to our api call, t
hats what Ive added here, choosing which forms to fetch will be specified via this flag: `__formTypes`
In addition added the flag to the doc containing all the flags here : https://docs.google.com/spreadsheets/d/1VXoSCLMNeB9I_OELKj9iIM3lzA1RQyxU9eEA4zGNuWM/edit#gid=0

