### PR TITLE
Typeform Data Source — New Version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,17 +2,17 @@ from distutils.core import setup
 
 setup(
     name="panoply_typeform",
-    version="1.1.0",
+    version="1.2.0",
     description="Panoply Data Source for the Typeform API",
     author="Alon Weissfeld",
     author_email="alon.weissfeld@panoply.io",
     url="http://panoply.io",
     package_dir={"panoply": ""},
     install_requires=[
-        "panoply-python-sdk==1.5.0",
-        "requests==2.20.1",
-        "backoff==1.7.1",
-        "ratelimit==2.2.0"
+        "panoply-python-sdk==1.6.0",
+        "requests==2.21.0",
+        "backoff==1.8.0",
+        "ratelimit==2.2.1"
     ],
     extras_require={
         "test": [

--- a/typeform/typeform.py
+++ b/typeform/typeform.py
@@ -124,7 +124,6 @@ class Typeform(DataSource):
         params = {
             'page_size': page_size,
             'sort': 'landed_at,desc',
-            # 'completed': 1,  # remove the line if you want to include both
         }
 
         params.update(completed)


### PR DESCRIPTION
[Asana Task — TypeForm data source: 404 Error on load](https://app.asana.com/0/280843276935180/797693123667337/f)

## Description
- Upgraded the version of Typeform Data Source to `v1.2.0`.
- Upgraded the versions of the third party libraries to newer.
- Removed the unused line which was priorly commented out.

## To-do
- [ ] Tag the release as `v1.2.0` after merging the changes.